### PR TITLE
prefer `respond_to?` over `is_a?`

### DIFF
--- a/lib/paper_trail_globalid/paper_trail.rb
+++ b/lib/paper_trail_globalid/paper_trail.rb
@@ -1,7 +1,7 @@
 module PaperTrailGlobalid
   module PaperTrail
     def whodunnit=(value)
-      if value.is_a? ActiveRecord::Base
+      if value.respond_to?(:to_gid)
         paper_trail_store[:whodunnit] = value.to_gid
       else
         paper_trail_store[:whodunnit] = value


### PR DESCRIPTION
In a work project, we were surprised when `actor` started returning strings rather than objects. The bug started after we started wrapping the `current_user` method in a presenter such that `user_for_paper_trail` was no longer `is_a?(ActiveRecord::Base)` but did `respond_to?(:to_gid)`.

There are definitely tradeoffs here but this seems better.