### PR TITLE
Don't blow up when whodunnit is not a persisted record

### DIFF
--- a/lib/paper_trail_globalid/paper_trail.rb
+++ b/lib/paper_trail_globalid/paper_trail.rb
@@ -2,7 +2,7 @@ module PaperTrailGlobalid
   module PaperTrail
     def whodunnit=(value)
       if value.is_a? ActiveRecord::Base
-        paper_trail_store[:whodunnit] = value.to_gid
+        paper_trail_store[:whodunnit] = value.persisted? ? value.to_gid : nil
       else
         paper_trail_store[:whodunnit] = value
       end

--- a/lib/paper_trail_globalid/version.rb
+++ b/lib/paper_trail_globalid/version.rb
@@ -1,3 +1,3 @@
 module PaperTrailGlobalid
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/paper_trail_globalid/version_concern.rb
+++ b/lib/paper_trail_globalid/version_concern.rb
@@ -2,7 +2,7 @@ module PaperTrailGlobalid
   module VersionConcern
     def whodunnit=(value)
       if value.is_a? ActiveRecord::Base
-        super(value.to_gid)
+        super(value.persisted? ? value.to_gid : nil)
       else
         super
       end


### PR DESCRIPTION
If unpersisted values are set as `whodunnit` (this happens a lot in test but could happen in a model construction), we can 

- Blow up (current behavior)
- Use `nil` for whodunnit
- Use a non-functional global id partial

This changes opts for the second, as blowing up is not helpful for an audit trail, and a non-functional gid partial (e.g. with null as the id) is likely to cause more confusion than solve problems

Error example

```rb
PaperTrail.request(whodunnit: User.new) { MediaFile.last.update!(name: Time.zone.now.to_s) }

URI::GID::MissingModelIdError (Unable to create a Global ID for User without a model id.)
```