### PR TITLE
Allow for using custom paper trail version classes

### DIFF
--- a/lib/paper_trail_globalid/version_concern.rb
+++ b/lib/paper_trail_globalid/version_concern.rb
@@ -1,11 +1,12 @@
 module PaperTrailGlobalid
   module VersionConcern
-    def whodunnit=(value)
-      if value.is_a? ActiveRecord::Base
-        super(value.to_gid)
+    def whodunnit=(input_value)
+      whodunnit_value = if input_value.is_a?(ActiveRecord::Base)
+        input_value.to_gid
       else
-        super
+        input_value
       end
+      _write_attribute("whodunnit", whodunnit_value)
     end
 
     # Returns an object which was responsible for a change

--- a/spec/paper_trail_globalid_spec.rb
+++ b/spec/paper_trail_globalid_spec.rb
@@ -1,22 +1,27 @@
 require 'spec_helper'
 require_relative '../spec/support/order.rb'
 require_relative '../spec/support/admin.rb'
-
+require_relative '../spec/support/product.rb'
 
 describe PaperTrailGlobalid do
   before(:all) do
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Schema.define do
+      create_table :admins, force: true do |t|
+        t.string :name
+      end
+
       create_table :orders, force: true do |t|
         t.string :order_number
         t.integer :total
       end
 
-      create_table :admins, force: true do |t|
+      create_table :products, force: true do |t|
         t.string :name
+        t.integer :price_in_cents
       end
 
-      create_table :versions do |t|
+      version_column_setter = ->(t) do
         t.string   :item_type, :null => false
         t.integer  :item_id,   :null => false
         t.string   :event,     :null => false
@@ -24,13 +29,20 @@ describe PaperTrailGlobalid do
         t.text     :object,    :limit => 1_073_741_823
         t.datetime :created_at
       end
+
+      create_table :versions, force: true, &version_column_setter
+
+      create_table :product_versions, force: true, &version_column_setter
     end
   end
 
   after(:all) do
     ActiveRecord::Schema.define do
+      drop_table :admins
       drop_table :orders
+      drop_table :products
       drop_table :versions
+      drop_table :product_versions
     end
     ActiveRecord::Migration.verbose = true
   end
@@ -39,8 +51,6 @@ describe PaperTrailGlobalid do
     before do
       GlobalID.app = "App"
       @admin = Admin.create(name: 'admin')
-      @order = Order.create!(order_number: 'ord_1', total: 100)
-      @version = @order.versions.last
     end
 
     describe 'paper_trail' do
@@ -81,40 +91,60 @@ describe PaperTrailGlobalid do
 
     describe 'version_concern' do
       describe 'instance_methods' do
-        describe '#actor' do
-          context 'when value for whodunnit is object of ActiveRecord' do
-            it 'returns object' do
-              @version.whodunnit = @admin
-              @version.save
-              expect(@version.actor).to eq(@admin)
+        shared_examples 'a paper_trail version that uses paper_trail_gobalid' do
+          describe '#actor' do
+            context 'when value for whodunnit is object of ActiveRecord' do
+              it 'returns object' do
+                @version.whodunnit = @admin
+                @version.save
+                expect(@version.actor).to eq(@admin)
+              end
+            end
+
+            context 'when value for whodunnit is not an object of ActiveRecord' do
+              it 'returns value itself' do
+                @version.whodunnit = "test"
+                @version.save
+                expect(@version.actor).to eq("test")
+              end
             end
           end
 
-          context 'when value for whodunnit is not an object of ActiveRecord' do
-            it 'returns value itself' do
-              @version.whodunnit = "test"
-              @version.save
-              expect(@version.actor).to eq("test")
+          describe '#whodunnit' do
+            context 'when value for whodunnit is object of ActiveRecord' do
+              it 'returns global id' do
+                @version.whodunnit = @admin
+                @version.save
+                expect(@version.whodunnit).to eq(@admin.to_gid.to_s)
+              end
+            end
+
+            context 'when value for whodunnit is not an object of ActiveRecord' do
+              it 'returns value itself' do
+                @version.whodunnit = "test"
+                @version.save
+                expect(@version.whodunnit).to eq("test")
+              end
             end
           end
         end
 
-        describe '.whodunnit' do
-          context 'when value for whodunnit is object of ActiveRecord' do
-            it 'returns global id' do
-              @version.whodunnit = @admin
-              @version.save
-              expect(@version.whodunnit).to eq(@admin.to_gid.to_s)
-            end
+        context "when using the built in paper_trail version class" do
+          before do
+            order = Order.create!(order_number: 'ord_1', total: 100)
+            @version = order.versions.last
           end
 
-          context 'when value for whodunnit is not an object of ActiveRecord' do
-            it 'returns value itself' do
-              @version.whodunnit = "test"
-              @version.save
-              expect(@version.whodunnit).to eq("test")
-            end
+          it_behaves_like 'a paper_trail version that uses paper_trail_gobalid'
+        end
+
+        context "when using a custom version class" do
+          before do
+            product = Product.create!(name: 'Coffee cup', price_in_cents: 1500)
+            @version = product.versions.last
           end
+
+          it_behaves_like 'a paper_trail version that uses paper_trail_gobalid'
         end
       end
     end

--- a/spec/support/product.rb
+++ b/spec/support/product.rb
@@ -1,0 +1,17 @@
+require 'paper_trail'
+require 'paper_trail-globalid'
+
+# See https://github.com/paper-trail-gem/paper_trail#6a-custom-version-classes
+
+class ApplicationVersion < ActiveRecord::Base
+  include PaperTrail::VersionConcern
+  self.abstract_class = true
+end
+
+class ProductVersion < ApplicationVersion
+  self.table_name = :product_versions
+end
+
+class Product < ActiveRecord::Base
+  has_paper_trail versions: { class_name: "ProductVersion" }
+end


### PR DESCRIPTION
### Motivation / Background

Fixes #13

This Pull Request has been created to update paper_trail-globalid to work with custom paper trail version classes, see https://github.com/paper-trail-gem/paper_trail#6a-custom-version-classes

### Detail

This Pull Request changes the implementation so that we call `#_write_attribute` instead of `#super`, this way abstract classes which include `::PaperTrail::VersionConcern` can still set whodunnit without raising an error.
